### PR TITLE
Support 500 throwing while others retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.9.6",
     "@types/compression": "^0.0.36",
+    "@types/shelljs": "^0.8.5",
     "compression": "^1.0.3",
     "express": "^4.16.3",
     "fast-text-encoding": "^1.0.0",

--- a/src/client/__tests__/stream_retrier.test.ts
+++ b/src/client/__tests__/stream_retrier.test.ts
@@ -136,7 +136,7 @@ function getRetryingStreamEvents<T>(
   for (const event of ['ready', 'complete', 'canceled'] as [
     'ready',
     'complete',
-    'canceled'
+    'canceled',
   ]) {
     retryingStream.on(event, () => {
       events.push([event]);

--- a/src/client/backoff.ts
+++ b/src/client/backoff.ts
@@ -16,6 +16,7 @@ export interface BackoffOptions {
   constantBackoffMs: number;
   maxBackoffMs: number;
   maxRetries: number;
+  statusCodesToIgnore: number[];
 }
 
 /** Default options for an exponential backoff. */
@@ -24,6 +25,7 @@ export const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
   constantBackoffMs: 500,
   maxBackoffMs: 3000,
   maxRetries: -1,
+  statusCodesToIgnore: [],
 };
 
 /**

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -56,6 +56,7 @@ export class ClientRpcError<ResponseContext = any> extends ClientError {
    * @param context Response context given back by the RPC.
    */
   constructor(
+    readonly status: number,
     readonly errorType: ModuleRpcCommon.RpcErrorType,
     readonly msg?: string,
     readonly context?: ResponseContext,

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -119,7 +119,7 @@ export class Service<
           }
         })
         .on('canceled', () => {
-          reject(new ClientRpcError(ModuleRpcCommon.RpcErrorType.canceled));
+          reject(new ClientRpcError(0, ModuleRpcCommon.RpcErrorType.canceled));
         })
         .start();
     });
@@ -226,7 +226,7 @@ export type ServiceMethodMap<
     type: typeof ModuleRpcCommon.ServiceMethodType.serverStream;
   }
     ? ServerStreamMethod<serviceDefinition, method>
-    : UnaryMethod<serviceDefinition, method>
+    : UnaryMethod<serviceDefinition, method>;
 } & {
   [serviceKey]: Service<serviceDefinition, ResponseContext>;
 };

--- a/src/client/stream.ts
+++ b/src/client/stream.ts
@@ -210,7 +210,7 @@ export function streamAsPromise<Message>(
         reject(err);
       })
       .on('canceled', () => {
-        reject(new ClientRpcError(ModuleRpcCommon.RpcErrorType.canceled));
+        reject(new ClientRpcError(0, ModuleRpcCommon.RpcErrorType.canceled));
       })
       .on('complete', () => {
         accept(messages);

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -153,7 +153,7 @@ export type UnaryMethodsFor<
         type: typeof ServiceMethodType.serverStream;
       }
         ? never
-        : method
+        : method;
     }
   >,
   string

--- a/src/context/client/composite.ts
+++ b/src/context/client/composite.ts
@@ -19,7 +19,7 @@ export type CompositeClientContextConnectorsFor<
 > = {
   [connectorName in keyof ResponseContext]: ModuleRpcClient.ClientContextConnector<
     ResponseContext[connectorName]
-  >
+  >;
 };
 
 export class CompositeClientContextConnector<

--- a/src/context/client/timestamp.ts
+++ b/src/context/client/timestamp.ts
@@ -29,9 +29,7 @@ export class TimestampClientContextConnector
       ];
     if (!date) {
       throw new ModuleRpcClient.ResponseContextDecodingError(
-        `${
-          ModuleRpcContextCommon.timestampContextKeys.serverTimestamp
-        } context key is required`,
+        `${ModuleRpcContextCommon.timestampContextKeys.serverTimestamp} context key is required`,
       );
     }
     return {

--- a/src/context/server/composite.ts
+++ b/src/context/server/composite.ts
@@ -19,7 +19,7 @@ export type CompositeServerContextConnectorsFor<
 > = {
   [connectorName in keyof RequestContext]: ModuleRpcServer.ServerContextConnector<
     RequestContext[connectorName]
-  >
+  >;
 };
 
 export class CompositeServerContextConnector<

--- a/src/protocol/grpc_web/client/client.ts
+++ b/src/protocol/grpc_web/client/client.ts
@@ -250,6 +250,7 @@ class GrpcWebStream<Request, Response, ResponseContext>
             this.emit(
               'error',
               new ModuleRpcClient.ClientRpcError(
+                0,
                 ModuleRpcCommon.RpcErrorType.unavailable,
                 err.stack || /* istanbul ignore next */ err.message,
               ),
@@ -332,6 +333,7 @@ class GrpcWebStream<Request, Response, ResponseContext>
     if (error) {
       this.transport.cancel();
       throw new ModuleRpcClient.ClientRpcError<ResponseContext>(
+        status,
         error.errorType,
         error.message,
         responseContext,
@@ -341,6 +343,7 @@ class GrpcWebStream<Request, Response, ResponseContext>
     if (status !== 200) {
       const { type, message } = guessErrorTypeAndMessageFromHttpStatus(status);
       throw new ModuleRpcClient.ClientRpcError<ResponseContext>(
+        status,
         type,
         message,
         responseContext,
@@ -372,6 +375,7 @@ class GrpcWebStream<Request, Response, ResponseContext>
               this.emit(
                 'error',
                 new ModuleRpcClient.ClientRpcError<ResponseContext>(
+                  0,
                   error.errorType,
                   error.message,
                   this.responseContext,
@@ -415,6 +419,7 @@ class GrpcWebStream<Request, Response, ResponseContext>
       this.emit(
         'error',
         new ModuleRpcClient.ClientRpcError(
+          0,
           ModuleRpcCommon.RpcErrorType.unavailable,
         ),
       );

--- a/src/protocol/grpc_web/private/grpc.ts
+++ b/src/protocol/grpc_web/private/grpc.ts
@@ -60,7 +60,7 @@ export const enum GrpcErrorCode {
 
 /** Conversion table from error types to gRPC statuses. */
 export const errorTypesToGrpcStatuses: {
-  [errorType in ModuleRpcCommon.RpcErrorType]: GrpcErrorCode
+  [errorType in ModuleRpcCommon.RpcErrorType]: GrpcErrorCode;
 } = {
   [ModuleRpcCommon.RpcErrorType.canceled]: GrpcErrorCode.Canceled,
   [ModuleRpcCommon.RpcErrorType.unknown]: GrpcErrorCode.Unknown,

--- a/src/protocol/grpc_web/private/http_status.ts
+++ b/src/protocol/grpc_web/private/http_status.ts
@@ -11,7 +11,7 @@ import { ModuleRpcCommon } from '../../../common';
 
 /** Exhaustively associate error types to HTTP status codes. */
 export const errorTypesToHttpStatuses: {
-  [errorType in ModuleRpcCommon.RpcErrorType]: number
+  [errorType in ModuleRpcCommon.RpcErrorType]: number;
 } = {
   [ModuleRpcCommon.RpcErrorType.unknown]: HttpStatus.internalServerError,
   [ModuleRpcCommon.RpcErrorType.canceled]: HttpStatus.internalServerError,

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -40,7 +40,7 @@ export type ServiceHandlerFor<
     type: typeof ModuleRpcCommon.ServiceMethodType.serverStream;
   }
     ? ServerStreamMethodHandler<serviceDefinition, method, Context>
-    : UnaryMethodHandler<serviceDefinition, method, Context>
+    : UnaryMethodHandler<serviceDefinition, method, Context>;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,6 +209,15 @@
   resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.1.tgz#df7421e8bcb351b430bfbfa5c52bb353826ac94f"
   integrity sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==
 
+"@types/glob@*":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -224,7 +233,7 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
   integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
-"@types/minimatch@3.0.3":
+"@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -263,6 +272,14 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/shelljs@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
+  integrity sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/sinon@^7.0.13":
   version "7.0.13"


### PR DESCRIPTION
I have not clue who I need to get permissions from, or if there's any tests or anything to verify how this works, but the purpose is simply that by passing in an option `statusCodesToIgnore`, that withRetry, we still can throw errors on the client side

Also fixes CI types